### PR TITLE
Remove extra semicolon

### DIFF
--- a/src/ui/src/ui/bottomBar/template/template.css
+++ b/src/ui/src/ui/bottomBar/template/template.css
@@ -12,6 +12,6 @@
 .bar_visible
 {
 	opacity: 0.9;
-	display: block;;
+	display: block;
 }
 


### PR DESCRIPTION
`npm run build` fails cause of it with next error:
```
webpack-runtime-analyzer/node_modules/css-tree/lib/utils/names.js:65
    var hack = property[0];
                       ^
TypeError: Cannot read property '0' of undefined
```